### PR TITLE
Downloading video streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+plugin.video.ardmediathek_de
+============================
+
+Fork for implementing video download capabilities.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 plugin.video.ardmediathek_de
 ============================
 
-Fork for implementing video download capabilities.
+Information: http://wiki.xbmc.org/index.php?title=Add-on:ARD_Mediathek
+Features: Streaming and downloading videos from http://www.ardmediathek.de/

--- a/addon.xml
+++ b/addon.xml
@@ -2,6 +2,7 @@
 <addon id="plugin.video.ardmediathek_de" name="ARD Mediathek" version="2.0.8" provider-name="AddonScriptorDE">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>
+        <import addon="script.module.simple.downloader" version="1.9.4" />
     </requires>
     <extension point="xbmc.python.pluginsource" library="default.py">
         <provides>video</provides>

--- a/default.py
+++ b/default.py
@@ -21,6 +21,7 @@ useThumbAsFanart=addon.getSetting("useThumbAsFanart") == "true"
 viewMode = str(addon.getSetting("viewMode"))
 errorMessageDurationSec = 20
 characterEncoding = "iso-8859-15"
+configEnableDownloadFeature = False
 
 baseUrl = "http://www.ardmediathek.de"
 defaultThumb = baseUrl+"/ard/static/pics/default/16_9/default_webM_16_9.jpg"
@@ -549,7 +550,9 @@ def addLink(name, url, mode, iconimage, duration="", desc=""):
     else:
         liz.setProperty("fanart_image", defaultBackground)
     liz.addContextMenuItems([(translation(30012), 'RunPlugin(plugin://'+addonID+'/?mode=queueVideo&url='+urllib.quote_plus(u)+'&name='+urllib.quote_plus(name)+')',)])
-    liz.addContextMenuItems([(translation(30040), 'RunPlugin(plugin://'+addonID+'/?mode=downloadVideo&url='+urllib.quote_plus(url)+'&name='+urllib.quote_plus(name)+')',)])
+    if configEnableDownloadFeature:
+        liz.addContextMenuItems([(translation(30040), 'RunPlugin(plugin://'+addonID+'/?mode=downloadVideo&url='+urllib.quote_plus(url)+'&name='+urllib.quote_plus(name)+')',)])
+    # else: downloading is not allowed
     ok = xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url=u, listitem=liz)
     return ok
 

--- a/default.py
+++ b/default.py
@@ -235,10 +235,11 @@ def extractVideoDescription(entry):
         if match:
             date = match[0][0]
             duration = match[0][1]
+            duration = duration.replace("min", "").strip()
             if "00:" in duration:
                 # XBMC will round this duration to zero. Thus, we set it to at least one minute
                 # (do not return an int, because it is normally a string)
-                duration = "01:00 min"
+                duration = "01:00"
         # thumbs
         match = re.compile('src="(.+?)"', re.DOTALL).findall(entry)
         thumb = getBetterThumb(baseUrl+match[0])
@@ -534,7 +535,12 @@ def addLink(name, url, mode, iconimage, duration="", desc=""):
     u = sys.argv[0]+"?url="+urllib.quote_plus(url)+"&mode="+str(mode)
     ok = True
     liz = xbmcgui.ListItem(name, iconImage=defaultThumb, thumbnailImage=iconimage)
-    liz.setInfo(type="Video", infoLabels={"Title": name, "Duration": duration, "Plot": desc})
+    infos = {"Title": name}
+    if duration:
+        infos["Duration"] = duration
+    if desc:
+        infos["Plot"] = desc
+    liz.setInfo(type="Video", infoLabels=infos)
     liz.setProperty('IsPlayable', 'true')
     if useThumbAsFanart:
         if not iconimage or iconimage==icon:

--- a/default.py
+++ b/default.py
@@ -88,7 +88,7 @@ def listDossiers():
         url = baseUrl+match[0]
         id = url[url.find("documentId=")+11:]
         url = baseUrl+"/ard/servlet/ajax-cache/3517004/view=list/documentId="+id+"/goto=1/index.html"
-        match = re.compile('<span class="mt-icon mt-icon-toggle_arrows"></span>\n                (.+?)\n', re.DOTALL).findall(entry)
+        match = re.compile('<span class="mt-icon mt-icon-toggle_arrows"></span>\n                (.+?)</a>\n', re.DOTALL).findall(entry)
         title = cleanTitle(match[0])
         match = re.compile('src="(.+?)"', re.DOTALL).findall(entry)
         thumb = getBetterThumb(baseUrl+match[0])

--- a/default.py
+++ b/default.py
@@ -182,6 +182,7 @@ def iterateContent(url, videoOnly, nextPageAction, callbackForVideo, separator='
                 #print("Content entry: " +title +" (" +pageurl +") " +duration +" - " +channel +" - " +show +" - descr:" +desc +" - date:" +date)
                 callbackForVideo(title, pageurl, thumb, duration, channel, show, desc, date)
             else:
+                # error handling for web page without any information
                 print("Ignoring entry without title and URL.")
     
     # have a look for some "next page" indicator
@@ -515,18 +516,18 @@ def parameters_string_to_dict(parameters):
 
 #
 # Callback per video for list function
+# (at least title and pageurl have to be valid)
 #
 def createVideoEntry(title, pageurl, thumb, duration, channel, show, desc, date):
-    # error handling for web page without any information
-    if not title:
-        title = "?"
     if "Livestream" not in title:
         if not desc:
             desc = cleanTitle(date+" - "+show+" ("+channel+")")
-        if date:
+        if show and addon.getSetting("showSeriesInTitle") == "true":
+            title = show +": " +title
+        if date and addon.getSetting("showDateInTitle") == "true":
             # add date to title
-            title = date[:6]+" - "+title
-        addLink(title, pageurl, 'playVideo', thumb, duration)
+            title = date[:6]+" "+title
+        addLink(cleanTitle(title), pageurl, 'playVideo', thumb, duration, desc)
 
 
 def addLink(name, url, mode, iconimage, duration="", desc=""):

--- a/default.py
+++ b/default.py
@@ -228,7 +228,8 @@ def extractVideoDescription(entry):
         if match:
             channel = match[0]
         # duration and date
-        match = re.compile('<span class="mt-airtime">\n                    (.+?)\n                    (.+?) min\n            </span>', re.DOTALL).findall(entry)
+        # (encoded as "15.01.14 16:46 min" or in the search results as "15.01.14 - 16:46 min"
+        match = re.compile('<span class="mt-airtime">([0-9\.]+)[^0-9]*([0-9:]+ min)?</span>', re.DOTALL).findall(entry)
         if match:
             date = match[0][0]
             duration = match[0][1]
@@ -524,7 +525,7 @@ def createVideoEntry(title, pageurl, thumb, duration, channel, show, desc, date)
             desc = cleanTitle(date+" - "+show+" ("+channel+")")
         if date:
             # add date to title
-            title = date[:5]+" - "+title
+            title = date[:6]+" - "+title
         addLink(title, pageurl, 'playVideo', thumb, duration)
 
 

--- a/default.py
+++ b/default.py
@@ -164,7 +164,7 @@ def getBetterThumb(url):
 # Iterates over a web page and identifies all listed content elements (e.g. video/audio)
 #
 def iterateContent(url, videoOnly, nextPageAction, callbackForVideo, separator='<div class="mt-media_item">'):
-    print("list content for " +url)
+    #print("list content for " +url)
     content = getUrl(url)
     # find relevant parts of web page
     spl = content.split(separator)
@@ -179,6 +179,7 @@ def iterateContent(url, videoOnly, nextPageAction, callbackForVideo, separator='
             title, pageurl, thumb, duration, channel, show, desc, date = extractVideoDescription(entry)
             # was analysis successful?
             if title and pageurl:
+                #print("Content entry: " +title +" (" +pageurl +") " +duration +" - " +channel +" - " +show +" - descr:" +desc +" - date:" +date)
                 callbackForVideo(title, pageurl, thumb, duration, channel, show, desc, date)
             else:
                 print("Ignoring entry without title and URL.")
@@ -284,10 +285,7 @@ def extractStreamURL(url):
     matchFSK = re.compile('<div class="fsk">(.+?)</div>', re.DOTALL).findall(content)
     if matchFSK:
         fsk = matchFSK[0].strip()
-        if fsk:
-            return None, fsk
-        else:
-            return None, content
+        return None, fsk
     else:
         match5 = re.compile('addMediaStream\\(1, 2, "", "(.+?)"', re.DOTALL).findall(content)
         match6 = re.compile('addMediaStream\\(1, 1, "", "(.+?)"', re.DOTALL).findall(content)
@@ -320,7 +318,7 @@ def extractStreamURL(url):
                 url = url[:url.find("?")]
             return url, None
         else:
-            return None, content
+            return None, None
 
 
 #
@@ -328,13 +326,15 @@ def extractStreamURL(url):
 #
 def playVideo(url):
     streamURL, errorMsg = extractStreamURL(url)
-    print("Playing " +streamURL +" (web page = " +url +")")
     if streamURL:
+        print("Playing " +streamURL +" (web page = " +url +")")
         listitem = xbmcgui.ListItem(path=streamURL)
         xbmcplugin.setResolvedUrl(pluginhandle, True, listitem)
         if showSubtitles and matchUT:
             setSubtitle(baseUrl+matchUT[0])
     else:
+        if not errorMsg:
+            errorMsg = url;
         reportError(translation(30200), translation(30202) +" " +errorMsg)
 
 

--- a/default.py
+++ b/default.py
@@ -176,10 +176,10 @@ def iterateContent(url, videoOnly, nextPageAction, callbackForVideo, separator='
             if "mt-icon_video" not in entry:
                 useEntry = False
         if useEntry:
-            title, streamurl, thumb, duration, channel, show, desc, date = extractVideoDescription(entry)
+            title, pageurl, thumb, duration, channel, show, desc, date = extractVideoDescription(entry)
             # was analysis successful?
-            if title and streamurl:
-                callbackForVideo(title, streamurl, thumb, duration, channel, show, desc, date)
+            if title and pageurl:
+                callbackForVideo(title, pageurl, thumb, duration, channel, show, desc, date)
             else:
                 print("Ignoring entry without title and URL.")
     

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -29,7 +29,9 @@
   <string id="30103">Use thumb as fanart</string>
   <string id="30104">Activate subtitles (if available)</string>
   <string id="30105">Destination folder for downloaded videos</string>
-
+  <string id="30106">Show date in video title</string>
+  <string id="30107">Show name of series in video title</string>
+  
   <string id="30200">Error</string>
   <string id="30201">Plug-in SimpleDownloader required for downloading not found. Maybe it has to be installed first.</string>
   <string id="30202">Stream URL can not be determined. Error:</string>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -22,8 +22,16 @@
   <string id="30028">Add to addon favs</string>
   <string id="30029">Remove from addon favs</string>
   <string id="30030">Play alternative Stream-URL</string>
+  <string id="30040">Download video</string>
+  
   <string id="30101">Force View</string>
   <string id="30102">ViewID</string>
   <string id="30103">Use thumb as fanart</string>
   <string id="30104">Activate subtitles (if available)</string>
+  <string id="30105">Destination folder for downloaded videos</string>
+
+  <string id="30200">Error</string>
+  <string id="30201">Plug-in SimpleDownloader required for downloading not found. Maybe it has to be installed first.</string>
+  <string id="30202">Stream URL can not be determined. Web page:</string>
+  <string id="30203">Destination folder not defined. Please define it in the configuration section of this plug-in.</string>
 </strings>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -32,6 +32,6 @@
 
   <string id="30200">Error</string>
   <string id="30201">Plug-in SimpleDownloader required for downloading not found. Maybe it has to be installed first.</string>
-  <string id="30202">Stream URL can not be determined. Web page:</string>
+  <string id="30202">Stream URL can not be determined. Error:</string>
   <string id="30203">Destination folder not defined. Please define it in the configuration section of this plug-in.</string>
 </strings>

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -28,6 +28,8 @@
   <string id="30103">Thumb als Fanart nutzen</string>
   <string id="30104">Untertitel aktivieren (falls verfügbar)</string>
   <string id="30105">Zielordner für heruntergeladene Videos</string>
+  <string id="30106">Zeige Datum im Videotitel</string>
+  <string id="30107">Zeige Serienname im Videotitel</string>
 
   <string id="30200">Fehler</string>
   <string id="30201">Zum Herunterladen notwendiges Plugin SimpleDownloader nicht gefunden. Es muss möglicherweise erst installiert werden.</string>

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -22,7 +22,15 @@
   <string id="30028">Zu Addon Favs hinzufügen</string>
   <string id="30029">Aus Addon Favs entfernen</string>
   <string id="30030">Alternative Stream-Url abspielen</string>
+  <string id="30040">Video herunterladen</string>
+  
   <string id="30101">View erzwingen</string>
   <string id="30103">Thumb als Fanart nutzen</string>
   <string id="30104">Untertitel aktivieren (falls verfügbar)</string>
+  <string id="30105">Zielordner für heruntergeladene Videos</string>
+
+  <string id="30200">Fehler</string>
+  <string id="30201">Zum Herunterladen notwendiges Plugin SimpleDownloader nicht gefunden. Es muss möglicherweise erst installiert werden.</string>
+  <string id="30202">Stream-URL kann nicht bestimmt werden. Webseite:</string>
+  <string id="30203">Zielverzeichnis ist nicht definiert. Bitte Konfiguration des Plug-ins anpassen.</string>
 </strings>

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -31,6 +31,6 @@
 
   <string id="30200">Fehler</string>
   <string id="30201">Zum Herunterladen notwendiges Plugin SimpleDownloader nicht gefunden. Es muss möglicherweise erst installiert werden.</string>
-  <string id="30202">Stream-URL kann nicht bestimmt werden. Webseite:</string>
+  <string id="30202">Stream-URL kann nicht bestimmt werden. Fehler:</string>
   <string id="30203">Zielverzeichnis ist nicht definiert. Bitte Konfiguration des Plug-ins anpassen.</string>
 </strings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -3,4 +3,5 @@
    <setting id="useThumbAsFanart" type="bool" label="30103" default="true"/>
    <setting id="forceViewMode" type="bool" label="30101" default="true"/>
    <setting id="viewMode" type="number" label="30102" default="500"/>
+   <setting id="downloadFolder" type="folder" label="30105" default=""/>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,4 +4,6 @@
    <setting id="forceViewMode" type="bool" label="30101" default="true"/>
    <setting id="viewMode" type="number" label="30102" default="500"/>
    <setting id="downloadFolder" type="folder" label="30105" default=""/>
+   <setting id="showDateInTitle" type="bool" label="30106" default="true"/>
+   <setting id="showSeriesInTitle" type="bool" label="30107" default="true"/>
 </settings>


### PR DESCRIPTION
Hello!
It would be nice to be able to download the videos. I use this feature for slow DSL lines in order to avoid waiting for the buffering. Moreover, it is a nice feature for backing up videos removed from the mediathek too early.

Thus, I implemented a download feature comparable to the one in the YouTube plugin. The dependency to the SimpleDownloader plugin (which is doing the work) is optional. The code informs the user if it is not installed. The changes have been tested in XBMC 12.2 (German) on Windows and Linux. More details are given in cfc650a433a87cb05fc844c9695277c08103a6b4.

Since the new feature seems to be useful for others as well, I send you this pull request. Just send me a short message, if further changes are required. Best regards, Florian
